### PR TITLE
Asset url null crash + asset groups extra

### DIFF
--- a/android/src/main/java/re/notifica/flutter/NotificareUtils.java
+++ b/android/src/main/java/re/notifica/flutter/NotificareUtils.java
@@ -208,7 +208,7 @@ public class NotificareUtils {
         JSONObject assetMap = new JSONObject();
         assetMap.put("assetTitle", asset.getTitle());
         assetMap.put("assetDescription", asset.getDescription());
-        assetMap.put("assetUrl", (asset.getUrl() != null) ? asset.getUrl() : null);
+        assetMap.put("assetUrl", (asset.getUrl() != null) ? asset.getUrl().toString() : null);
         assetMap.put("assetExtra", asset.getExtra());
 
         JSONObject metaMap = new JSONObject();

--- a/android/src/main/java/re/notifica/flutter/NotificareUtils.java
+++ b/android/src/main/java/re/notifica/flutter/NotificareUtils.java
@@ -6,6 +6,7 @@ import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 import re.notifica.Notificare;
 import re.notifica.model.NotificareAction;
@@ -207,7 +208,8 @@ public class NotificareUtils {
         JSONObject assetMap = new JSONObject();
         assetMap.put("assetTitle", asset.getTitle());
         assetMap.put("assetDescription", asset.getDescription());
-        assetMap.put("assetUrl", asset.getUrl().toString());
+        assetMap.put("assetUrl", (asset.getUrl() != null) ? asset.getUrl() : null);
+        assetMap.put("assetExtra", asset.getExtra());
 
         JSONObject metaMap = new JSONObject();
         metaMap.put("originalFileName", asset.getOriginalFileName());

--- a/lib/notificare_models.dart
+++ b/lib/notificare_models.dart
@@ -376,6 +376,7 @@ class NotificareAsset {
   String assetUrl;
   NotificareAssetMetaData assetMetaData;
   NotificareAssetButton assetButton;
+  Map<String, dynamic> assetExtra;
   factory NotificareAsset.fromJson(Map<String, dynamic> json) =>
       _$NotificareAssetFromJson(json);
   Map<String, dynamic> toJson() => _$NotificareAssetToJson(this);

--- a/lib/notificare_models.g.dart
+++ b/lib/notificare_models.g.dart
@@ -539,7 +539,8 @@ NotificareAsset _$NotificareAssetFromJson(Map<String, dynamic> json) {
     ..assetButton = json['assetButton'] == null
         ? null
         : NotificareAssetButton.fromJson(
-            json['assetButton'] as Map<String, dynamic>);
+            json['assetButton'] as Map<String, dynamic>)
+    ..assetExtra = json['assetExtra'];
 }
 
 Map<String, dynamic> _$NotificareAssetToJson(NotificareAsset instance) =>
@@ -549,6 +550,7 @@ Map<String, dynamic> _$NotificareAssetToJson(NotificareAsset instance) =>
       'assetUrl': instance.assetUrl,
       'assetMetaData': instance.assetMetaData,
       'assetButton': instance.assetButton,
+      'assetExtra': instance.assetExtra,
     };
 
 NotificareAssetMetaData _$NotificareAssetMetaDataFromJson(


### PR DESCRIPTION
- Fixes a crash when `asset.getUrl()` returns null
- Adds `assetExtra`